### PR TITLE
[RDY] Process feedback Spoofax section

### DIFF
--- a/research/notes.org
+++ b/research/notes.org
@@ -88,9 +88,14 @@ its declarative nature, SDF3 is not limited to generating parsers and
 pretty printers: it can also be used for error recovery
 rules\nbsp\cite{deJonge12}, syntax highlighting rules and folding
 rules for editors (see section [[#sec:editor-serv]]).
-
-All of the other parts of Spoofax use the AST that is produced by a
-parser generated from an SDF3 specification.
+*** AST-based rules
+The meta-languages that will be discussed in the coming sections all
+have one property in common: all of them use /rules/ based on the AST
+in order to specify one of the parts of a language definition. The
+rules are said to be /syntax-directed/: the specification for one AST
+node (whether it be a static semantics, rewriting or dynamic semantics
+specification) is done by the specification of the children of that
+AST node\nbsp\cite{Winskel93}.
 ** Static Semantics
 :PROPERTIES:
 :CUSTOM_ID: sec:static-analysis
@@ -112,9 +117,10 @@ assertions on the type of that variable.
 :PROPERTIES:
 :CUSTOM_ID: sec:nabl
 :END:
-With /NaBL/ (pronounced /enable/), name binding and scoping rules can
-be specified declaratively\nbsp\cite{KonatKWV12}. Here is an example
-of the name binding and scoping rules for a class, from the /paplj/
+With /NaBL/ (pronounced /enable/), name binding and scoping can be
+specified declaratively using AST-based
+rules\nbsp\cite{KonatKWV12}. Here is an example of the name binding
+and scoping rules for a class, from the /paplj/
 language[fn:paplj:paplj is used as an exercise language for the
 "Declare Your Language" book, which is a work-in-progress at the time
 of writing. More information can be found here:
@@ -135,14 +141,10 @@ binding rules
     // Import namespaces from superclass
     imports Field, Method from Class c
 #+END_EXAMPLE
-The first line declares the /namespaces/ to consider. A namespace is a
-way to distinguish different kinds of
-names\nbsp\cite{KonatKWV12}. Then for each node in the AST resulting
-from the parsing, for example a =Class= node, the name binding and
-scoping rules can be defined. In the example, each =Class= node
-declares a new scope for its fields, methods and variables. It also
-implicitly defines the =this= variable. The =Extends= node can then
-import the fields and methods into its scope.
+The most important concept to take away from this example is the way
+the rules are specified on the AST: new scopes for names can be
+defined on the level of an AST node, and can be imported again by
+referring back to the scope definition.
 
 As can be seen from line 8, it can also associate type information
 with names to interplay with TS. The type annotations can also be used
@@ -167,10 +169,12 @@ type rules
       and e2 : NumT() else error "number expected" on e2
 
 #+END_EXAMPLE
-Rules can recursively set constraints on AST-nodes, such as the =Add=
-node in the above example.
+This example shows how in TS, the rules are syntax-directed: The
+typing rule of the =Add= node is specified by the types of its
+children $e_1$ and $e_2$, on which the typing rules will be applied
+recursively.
 
-Again, in line 5, interplay can be seen between TS an NaBL. Here the
+Again, in line 6, interplay can be seen between TS an NaBL. Here the
 type of a variable can be accessed, which is set in the NaBL
 specification (see the previous section [[#sec:nabl]]).
 ** Term Rewriting and Program Transformation
@@ -203,7 +207,9 @@ rules
   	Let([b1, b2 | bs], e) -> Let([b1], Let([b2 | bs], e))
 #+END_EXAMPLE
 This desugars a =let= expression with multiple bindings into multiple
-nested =let= expressions each having just one binding.
+nested =let= expressions each having just one binding. Again it can be
+seen that these are syntax-directed rules, from the way the rules are
+specified using the AST.
 
 To construct the main algorithm of the program transformation,
 Stratego has the notion of /strategies/. A strategy is used to specify
@@ -242,12 +248,12 @@ called /DynSem/\nbsp\cite{VerguNV15}. DynSem allows for an operational
 semantics specification from which a Java-based AST interpreter can be
 automatically generated.
 
-In DynSem, the dynamic semantics are specified by means of rules. To
-show how rules can define the dynamic semantics of a language,
-consider the classic example of the \beta-reduction, which defines
-function application in the lambda calculus. The rule replaces all the
-occurences of the parameter $x$ with the argument $e_2$, within the
-expression $e_1$:
+In DynSem, like other meta-languages in Spoofax, the dynamic semantics
+are specified by means of syntax-directed rules. To show how rules can
+define the dynamic semantics of a language, consider the classic
+example of the \beta-reduction, which defines function application in
+the lambda calculus. The rule replaces all the occurences of the
+parameter $x$ with the argument $e_2$, within the expression $e_1$:
 
 \begin{equation}
 (\lambda x.e_1) e_2 \rightarrow e_1[x := e_2]

--- a/research/notes.org
+++ b/research/notes.org
@@ -23,24 +23,39 @@ in a meta-language, the tokenizer and parser can be derived without
 the designer of the language ever having to care about its
 implementation.
 
-This section goes over the elements that make up the specification of
-a language. For each element the relevant part of Spoofax is
-given[fn:comp-constr-course:This section follows the structure of the
-language specification portion of the compiler construction course at
-the TU Delft. The slides can be found here:
-[[http://tudelft-in4303.github.io/lectures/specification/]].]. The parts
-of a language specification are:
+This section goes over the aspects that come into play with the
+development of a language and how Spoofax tackles each of these
+aspects. First, the section goes over the elements that make up the
+specification of a language[fn:comp-constr-course:This section follows
+the structure of the language specification portion of the compiler
+construction course at the TU Delft. The slides can be found here:
+[[http://tudelft-in4303.github.io/lectures/specification/]].]. A language
+specification consists of the following conceptual steps:
 
-1. [[#sec:syntax-def][Syntax Definition]]: Specifying the syntax of a language.
-2. [[#sec:static-analysis][Static Semantics]]: Describing the static analysis part of a
-   language (type checking, name binding and variable scoping).
-3. [[#sec:term-rewrite][Term Rewriting and Program Transformation]]: Rewriting abstract
-   syntax trees (ASTs) to new ASTs, for example to declare desugaring
-   rules.
-4. [[#sec:dynamic-semantics][Dynamic Semantics]]: Defining what the language does upon execution.
+1. [[#sec:syntax-def][Syntax Definition]]: The first step defines what textual
+   representations of a program are syntactically valid. A parser
+   provides an implementation of this definition, by mapping a textual
+   representation of a program to an abstract syntax tree (AST)
+   representation. In Spoofax, the syntax is declared with a DSL
+   called SDF.
+2. [[#sec:static-analysis][Static Semantics]]: The AST then goes through static analysis (type
+   checking, name binding and variable scoping), to test if the
+   program is well-formed. Static semantics describe the rules for the
+   static analysis step. Spoofax provides two DSLs for the
+   specification of this step: the TS type specification language and
+   the NaBL name binding language.
+3. [[#sec:term-rewrite][Term Rewriting and Program Transformation]]: Optionally, a
+   well-formed AST can then be transformed, for example for desugaring
+   or optimization. Spoofax provides Stratego for this step.
+4. [[#sec:dynamic-semantics][Dynamic Semantics]]: Next the optionally transformed AST is either
+   compiled or interpreted, thereby providing a means of
+   execution. Dynamic semantics define what the behaviour is of a
+   program upon execution. In Spoofax, the dynamic semantics can be
+   defined with either Stratego or a DSL called DynSem.
 
-After that, the section concludes with a description of [[#sec:editor-serv][Editor
-Services in Spoofax]].
+After that, this section concludes with a discussion on the other
+aspect of a language: its integrated development environment
+(IDE). Spoofax provides IDE support by means of its Editor Services.
 ** Syntax Definition
 :PROPERTIES:
 :CUSTOM_ID: sec:syntax-def

--- a/research/notes.org
+++ b/research/notes.org
@@ -36,8 +36,8 @@ specification consists of the following conceptual steps:
    representations of a program are syntactically valid. A parser
    provides an implementation of this definition, by mapping a textual
    representation of a program to an abstract syntax tree (AST)
-   representation. In Spoofax, the syntax is declared with a DSL
-   called SDF.
+   representation. In Spoofax, the syntax is declared with a domain
+   specific language (DSL) called SDF.
 2. [[#sec:static-analysis][Static Semantics]]: The AST then goes through static analysis (type
    checking, name binding and variable scoping), to test if the
    program is well-formed. Static semantics describe the rules for the
@@ -70,13 +70,12 @@ identifiers and numeric constants. The context-free grammar then
 defines syntactically valid sentences made up of words.
 
 *** SDF3: syntax definition in Spoofax
-To specify a syntax definition declaratively in Spoofax, a domain
-specific language (DSL) called /SDF3/\nbsp\cite{Vollebregt12} is used.
-SDF3 is the third generation of the /Syntax Definition Formalism/
-(SDF)\nbsp\cite{Heering89}. It uses only context-free grammer
-productions for the specification of both the lexical syntax and the
-context-free syntax, a feature that was introduced in
-SDF2\nbsp\cite{Visser97}.
+To specify a syntax definition declaratively in Spoofax, a DSL called
+/SDF3/\nbsp\cite{Vollebregt12} is used.  SDF3 is the third generation
+of the /Syntax Definition Formalism/ (SDF)\nbsp\cite{Heering89}. It
+uses only context-free grammer productions for the specification of
+both the lexical syntax and the context-free syntax, a feature that
+was introduced in SDF2\nbsp\cite{Visser97}.
 
 The declarative nature of SDF3 allows for thinking in terms of the
 structure (the /what/), instead of in terms of parser algorithms (the
@@ -239,8 +238,12 @@ traversal order on the AST nodes.
 The Spoofax API provides the =TranformService= for performing program
 transformation. Internally the =TransformService= accesses the
 Stratego runtime, which is retrieved from the
-=StrategoRuntimeService=. Stratego also has support for /native/
-strategies, which are specified in Java instead.
+=StrategoRuntimeService=. The same holds for the =AnalysisService= of
+the previous section: it too uses the Stratego runtime.
+
+Stratego furthermore has support for /native/ strategies, which are
+specified in Java instead. Therefore the interface is bidirectional:
+Stratego can hook into Java, and Java can use the Stratego API.
 ** Dynamic Semantics
 :PROPERTIES:
 :CUSTOM_ID: sec:dynamic-semantics

--- a/research/notes.org
+++ b/research/notes.org
@@ -231,10 +231,7 @@ Dynamic semantics refers to how a program written in some language
 behaves\nbsp\cite{Winskel93}. There are multiple approaches to
 formally specify the dynamic semantics of a programming language (for
 an extensive treatment, see\nbsp\cite{Winskel93}). For this section
-only one sort of approach is relevant, namely /rule-based operational/
-/semantics/ (see\nbsp\cite{Plotkin04} for a historical account of this
-approach).
-
+only one sort of approach is relevant, namely /operational semantics/.
 *** DynSem: rule-based dynamic semantics
 :PROPERTIES:
 :CUSTOM_ID: ssec:dynsem

--- a/research/notes.org
+++ b/research/notes.org
@@ -177,23 +177,21 @@ specification (see the previous section [[#sec:nabl]]).
 :PROPERTIES:
 :CUSTOM_ID: sec:term-rewrite
 :END:
-Spoofax offers a high level declarative DSL called /Stratego/ for
-program transformation\nbsp\cite{Visser01}. Stratego operates on ASTs
-and is the most general part of Spoofax: it can be used for specifying
-the static semantics (name binding, type checking), desugaring rules
-and the dynamic semantics of a language. As the static semantics can
-now be done using NaBL and TS and the dynamic semantics with DynSem
-(section [[#sec:dynamic-semantics]]), Stratego is now used to specify
-desugaring rules for a language, as well as optimizations such as
-constant folding and other applications of AST transformations.
+Sometimes the AST needs some form of transformation before it is to be
+compiled or executed, for example to transform it to a canonical form,
+or to perform optimizations such as constant folding. Program
+transformations are specified by /term rewrite rules/: The left-hand
+side of a rule introduces a pattern (for example $x + x$), and the
+right-hand side specifies a replacement for it (e.g. $2\cdot x$).
+*** Rewriting using Stratego
+Spoofax offers a DSL called /Stratego/ for specifying program
+transformation with rewrite rules\nbsp\cite{Visser01}. Stratego can be
+seen as the most general part of Spoofax: before NaBL and TS, Stratego
+was used for specifying the static semantics. Moreover, being a
+program transformation language, it can also serve as a compiler and
+can thus be used to specify the dynamic semantics.
 
-Stratego is based on the notions of /term rewrite rules/ and so-called
-/strategies/.
-*** Term rewrite rules
-A rewrite rule is a transformation on a term, in which the left-hand
-side allows for pattern matching and variable binding and the right
-hand side instantiates new replacement terms. An example of a rewrite
-rule for paplj is given below.
+An example of a rewrite rule for the paplj language is given below.
 #+LATEX: \lstset{language=stratego,numbers=left}
 #+ATTR_LATEX: :environment lstlisting
 #+BEGIN_EXAMPLE
@@ -206,11 +204,11 @@ rules
 #+END_EXAMPLE
 This desugars a =let= expression with multiple bindings into multiple
 nested =let= expressions each having just one binding.
-*** Strategies
-Strategies are used to select and apply term rewrite rules, to
-construct the main algorithm of the program transformation. One can
-use multiple combinators to compose rewrite rules and other
-strategies. Another example from paplj is given below:
+
+To construct the main algorithm of the program transformation,
+Stratego has the notion of /strategies/. A strategy is used to specify
+where and in what order the rewrite rules are applied to an
+AST. Another example from paplj is given below:
 #+LATEX: \lstset{language=stratego,numbers=left}
 #+ATTR_LATEX: :environment lstlisting
 #+BEGIN_EXAMPLE
@@ -222,7 +220,7 @@ strategies
     innermost(desugar-do <+ desugar-get <+ desugar-set);
     resugar
 #+END_EXAMPLE
-For example, the strategy =innermost= is used to apply the strategy
+The strategy =innermost= in this example is used to apply the strategy
 given as parameter (a composition of rewrite rules) in a specific
 traversal order on the AST nodes.
 ** Dynamic Semantics

--- a/research/notes.org
+++ b/research/notes.org
@@ -228,22 +228,19 @@ traversal order on the AST nodes.
 :CUSTOM_ID: sec:dynamic-semantics
 :END:
 Dynamic semantics refers to how a program written in some language
-behaves\nbsp\cite{Winskel93}. There are multiple approaches to
-formally specify the dynamic semantics of a programming language (for
-an extensive treatment, see\nbsp\cite{Winskel93}). For this section
-only one sort of approach is relevant, namely /operational semantics/.
+behaves\nbsp\cite{Winskel93}. There are many approaches to formally
+specify the dynamic semantics of a programming language (for an
+extensive treatment, see\nbsp\cite{Winskel93}). For this section only
+one sort of approach called /operational semantics/ is relevant.
 *** DynSem: rule-based dynamic semantics
 :PROPERTIES:
 :CUSTOM_ID: ssec:dynsem
 :END:
-In Spoofax, the dynamic semantics of a language used to be specified
-with Stratego. However, the Spoofax team has developed a more
-high-level method to declare the dynamic semantics of a language,
-namely a DSL called /DynSem/\nbsp\cite{VerguNV15}. As with all DSLs in
-Spoofax, DynSem offers a declarative approach to generate the
-/implementation/ out of the /specification/. Indeed, from a DynSem
-specification of a language, an interpreter for that language can be
-generated.
+Aside from Stratego, the Spoofax team has developed an additional
+method to declare the dynamic semantics of a language, namely a DSL
+called /DynSem/\nbsp\cite{VerguNV15}. DynSem allows for an operational
+semantics specification from which a Java-based AST interpreter can be
+automatically generated.
 
 In DynSem, the dynamic semantics are specified by means of rules. To
 show how rules can define the dynamic semantics of a language,
@@ -258,21 +255,22 @@ expression $e_1$:
 
 In a similar way, dynamic semantics can be specified in DynSem, in a
 syntax very similar to the formal syntax used in the literature. Take
-here the example of defining method calling in paplj:
+here the example of defining the behaviour of some boolean operators
+in paplj:
 #+LATEX: \lstset{language=dynsem,numbers=left}
 #+ATTR_LATEX: :environment lstlisting
 #+BEGIN_EXAMPLE
 rules
-  // ...
-  Call(o, m, vs: List(V)) --> v'
-    where lookupMethod(o, m) --> Method(_, _, params, e);
-          This o, Env bindVars(params, vs) |- e --> v'.
+  And(BoolV(false), _) --> BoolV(false).
+  And(BoolV(true), e)  --> e.
+
+  Or(BoolV(true), _)  --> BoolV(true).
+  Or(BoolV(false), e) --> e.
 #+END_EXAMPLE
-The bottom line represents the rule of the method body, $e$,
-evaluating to the return value $v'$, by binding the argument values to
-the parameter in the environment and binding the =this= variable to
-the object on which the method is called. Exactly how $e$ evaluates to
-$v'$ is defined using other rules, which are left out in this example.
+The example applies the standard rules for boolean operators, and is
+sufficient to specify the behaviour of these operators. The rules are
+recursively applied to the expression $e$ on the right-hand side of
+the rule until it eventually converges.
 #+LATEX: \lstset{numbers=none}
 
 ** Editor Services

--- a/research/notes.org
+++ b/research/notes.org
@@ -80,11 +80,11 @@ SDF2\nbsp\cite{Visser97}.
 
 The declarative nature of SDF3 allows for thinking in terms of the
 structure (the /what/), instead of in terms of parser algorithms (the
-/how/) as is the case with many current parsing
-algorithms\nbsp\cite{Kats10b}. The syntax definition is used to make
-parsers that parse a textual representation of a program into its AST
-and pretty-printers for mapping ASTs back to text. However, due to its
-declarative nature, SDF3 is not limited to generating parsers and
+/how/) as is the case with many current parser generators such as
+ANTLR and YACC\nbsp\cite{Kats10b}. The syntax definition is used to
+make parsers that parse a textual representation of a program into its
+AST and pretty-printers for mapping ASTs back to text. However, due to
+its declarative nature, SDF3 is not limited to generating parsers and
 pretty printers: it can also be used for error recovery
 rules\nbsp\cite{deJonge12}, syntax highlighting rules and folding
 rules for editors (see section [[#sec:editor-serv]]).

--- a/research/notes.org
+++ b/research/notes.org
@@ -236,9 +236,9 @@ The strategy =innermost= in this example is used to apply the strategy
 given as parameter (a composition of rewrite rules) in a specific
 traversal order on the AST nodes.
 
-The Spoofax API provides the =TranformService= for performing
-Transformation. Internally the =TransformService= access the Stratego
-runtime, which is accessed through the
+The Spoofax API provides the =TranformService= for performing program
+transformation. Internally the =TransformService= accesses the
+Stratego runtime, which is retrieved from the
 =StrategoRuntimeService=. Stratego also has support for /native/
 strategies, which are specified in Java instead.
 ** Dynamic Semantics
@@ -305,17 +305,18 @@ This section concludes with a brief description of editor services,
 which provide the IDE support for languages defined in
 Spoofax. Examples of such services include an outline view, menus in
 which one can bind actions to menu buttons (see figure
-[[fig:menu-actions]]), but also syntax highlighting, syntactic completion
-and code folding rules[fn:editor-serv-web:More services are listed on
-the Spoofax website:
+[[fig:menu-actions]]), but also syntax highlighting, syntactic code
+completion and code folding rules[fn:editor-serv-web:More services are
+listed on the Spoofax website:
 http://www.metaborg.org/spoofax/editor-services/].
 
 The Spoofax API provides the editor services with similar naming. For
 example, the outline can be retrieved from the =OutlineService=, the
 syntax highlighting can be accessed through the =StylerService= and
-syntactic completion is accessed with the =CompletionService=. The
-defined menus for a particular language can be retrieved with the
-=MenuService=, from which the menu actions can be retrieved and used.
+syntactic code completion is accessed with the
+=CompletionService=. The defined menus for a particular language can
+be retrieved with the =MenuService=, from which the menu actions can
+be retrieved and used.
 
 #+ATTR_LATEX: :width 0.6\textwidth
 #+CAPTION: A menu action for the paplj language defined using Spoofax. The bottom window shows the menu definition, the top window shows a program written in paplj.

--- a/research/notes.org
+++ b/research/notes.org
@@ -88,6 +88,9 @@ its declarative nature, SDF3 is not limited to generating parsers and
 pretty printers: it can also be used for error recovery
 rules\nbsp\cite{deJonge12}, syntax highlighting rules and folding
 rules for editors (see section [[#sec:editor-serv]]).
+
+The Spoofax API gives access to the generated parser through the
+=SyntaxService=.
 *** AST-based rules
 The meta-languages that will be discussed in the coming sections all
 have one property in common: all of them use /rules/ based on the AST
@@ -113,6 +116,9 @@ high-level DSLs exist for specifying static semantics declaratively:
 NaBL and TS. The two DSLs can work together: for instance, the type of
 a variable can be set with NaBL, so that TS can be used to make
 assertions on the type of that variable.
+
+The static analysis step of a language is exposed through the Spoofax
+API by the =AnalysisService=.
 *** NaBL: the Name Binding Language
 :PROPERTIES:
 :CUSTOM_ID: sec:nabl
@@ -229,6 +235,12 @@ strategies
 The strategy =innermost= in this example is used to apply the strategy
 given as parameter (a composition of rewrite rules) in a specific
 traversal order on the AST nodes.
+
+The Spoofax API provides the =TranformService= for performing
+Transformation. Internally the =TransformService= access the Stratego
+runtime, which is accessed through the
+=StrategoRuntimeService=. Stratego also has support for /native/
+strategies, which are specified in Java instead.
 ** Dynamic Semantics
 :PROPERTIES:
 :CUSTOM_ID: sec:dynamic-semantics
@@ -277,8 +289,14 @@ The example applies the standard rules for boolean operators, and is
 sufficient to specify the behaviour of these operators. The rules are
 recursively applied to the expression $e$ on the right-hand side of
 the rule until it eventually converges.
-#+LATEX: \lstset{numbers=none}
 
+DynSem generated interpreters can be accessed through the same APIs as
+those of Stratego, because the interpreter is a native Stratego
+strategy. Therefore, alternatively, the generated interpreter can also
+be accessed directly from Java provided that one has the AST of the
+program to interpret.
+
+#+LATEX: \lstset{numbers=none}
 ** Editor Services
 :PROPERTIES:
 :CUSTOM_ID: sec:editor-serv
@@ -287,9 +305,17 @@ This section concludes with a brief description of editor services,
 which provide the IDE support for languages defined in
 Spoofax. Examples of such services include an outline view, menus in
 which one can bind actions to menu buttons (see figure
-[[fig:menu-actions]]), but also syntax highlighting and code folding
-rules[fn:editor-serv-web:More services are listed on the Spoofax
-website: http://www.metaborg.org/spoofax/editor-services/].
+[[fig:menu-actions]]), but also syntax highlighting, syntactic completion
+and code folding rules[fn:editor-serv-web:More services are listed on
+the Spoofax website:
+http://www.metaborg.org/spoofax/editor-services/].
+
+The Spoofax API provides the editor services with similar naming. For
+example, the outline can be retrieved from the =OutlineService=, the
+syntax highlighting can be accessed through the =StylerService= and
+syntactic completion is accessed with the =CompletionService=. The
+defined menus for a particular language can be retrieved with the
+=MenuService=, from which the menu actions can be retrieved and used.
 
 #+ATTR_LATEX: :width 0.6\textwidth
 #+CAPTION: A menu action for the paplj language defined using Spoofax. The bottom window shows the menu definition, the top window shows a program written in paplj.
@@ -298,9 +324,9 @@ website: http://www.metaborg.org/spoofax/editor-services/].
 
 Editor services are defined using a DSL, shown in the bottom window of
 figure [[fig:menu-actions]]. In the case of menus, their actions are
-specified using Stratego. Via Stratego these actions can even be
-specified in Java. As such, Spoofax allows for defining arbitrarily
-complex IDE actions.
+specified using Stratego. Since Stratego supports native strategies,
+these actions can also be specified in Java. As such, Spoofax allows
+for defining arbitrarily complex IDE actions.
 
 Many of these editor services such as syntax highlighting and code
 folding rules can be derived from the syntax

--- a/research/references.bib
+++ b/research/references.bib
@@ -170,18 +170,6 @@
   publisher = {ACM},
   isbn = {978-1-4503-0203-6},
 }
-@article{Plotkin04,
-title = "The origins of structural operational semantics ",
-journal = "The Journal of Logic and Algebraic Programming ",
-volume = "60–61",
-number = "",
-pages = "3 - 15",
-year = "2004",
-issn = "1567-8326",
-doi = "http://dx.doi.org/10.1016/j.jlap.2004.03.009",
-url = "http://www.sciencedirect.com/science/article/pii/S1567832604000268",
-author = "Gordon D Plotkin",
-}
 @book{Winskel93,
  author = {Glynn Winskel},
  title = {The Formal Semantics of Programming Languages: An Introduction},

--- a/research/spoofax-org-export.tex
+++ b/research/spoofax-org-export.tex
@@ -14,26 +14,41 @@ in a meta-language, the tokenizer and parser can be derived without
 the designer of the language ever having to care about its
 implementation.
 
-This section goes over the elements that make up the specification of
-a language. For each element the relevant part of Spoofax is
-given\footnote{This section follows the structure of the
-language specification portion of the compiler construction course at
-the TU Delft. The slides can be found here:
-\url{http://tudelft-in4303.github.io/lectures/specification/}.}. The parts
-of a language specification are:
+This section goes over the aspects that come into play with the
+development of a language and how Spoofax tackles each of these
+aspects. First, the section goes over the elements that make up the
+specification of a language\footnote{This section follows
+the structure of the language specification portion of the compiler
+construction course at the TU Delft. The slides can be found here:
+\url{http://tudelft-in4303.github.io/lectures/specification/}.}. A language
+specification consists of the following conceptual steps:
 
 \begin{enumerate}
-\item \hyperref[sec:syntax-def]{Syntax Definition}: Specifying the syntax of a language.
-\item \hyperref[sec:static-analysis]{Static Semantics}: Describing the static analysis part of a
-language (type checking, name binding and variable scoping).
-\item \hyperref[sec:term-rewrite]{Term Rewriting and Program Transformation}: Rewriting abstract
-syntax trees (ASTs) to new ASTs, for example to declare desugaring
-rules.
-\item \hyperref[sec:dynamic-semantics]{Dynamic Semantics}: Defining what the language does upon execution.
+\item \hyperref[sec:syntax-def]{Syntax Definition}: The first step defines what textual
+representations of a program are syntactically valid. A parser
+provides an implementation of this definition, by mapping a textual
+representation of a program to an abstract syntax tree (AST)
+representation. In Spoofax, the syntax is declared with a DSL
+called SDF.
+\item \hyperref[sec:static-analysis]{Static Semantics}: The AST then goes through static analysis (type
+checking, name binding and variable scoping), to test if the
+program is well-formed. Static semantics describe the rules for the
+static analysis step. Spoofax provides two DSLs for the
+specification of this step: the TS type specification language and
+the NaBL name binding language.
+\item \hyperref[sec:term-rewrite]{Term Rewriting and Program Transformation}: Optionally, a
+well-formed AST can then be transformed, for example for desugaring
+or optimization. Spoofax provides Stratego for this step.
+\item \hyperref[sec:dynamic-semantics]{Dynamic Semantics}: Next the optionally transformed AST is either
+compiled or interpreted, thereby providing a means of
+execution. Dynamic semantics define what the behaviour is of a
+program upon execution. In Spoofax, the dynamic semantics can be
+defined with either Stratego or a DSL called DynSem.
 \end{enumerate}
 
-After that, the section concludes with a description of \hyperref[sec:editor-serv]{Editor
-Services in Spoofax}.
+After that, this section concludes with a discussion on the other
+aspect of a language: its integrated development environment
+(IDE). Spoofax provides IDE support by means of its Editor Services.
 \subsection{Syntax Definition}
 \label{sec:syntax-def}
 The first part of the specification of a language is its syntax. The

--- a/research/spoofax-org-export.tex
+++ b/research/spoofax-org-export.tex
@@ -72,11 +72,11 @@ SDF2~\cite{Visser97}.
 
 The declarative nature of SDF3 allows for thinking in terms of the
 structure (the \emph{what}), instead of in terms of parser algorithms (the
-\emph{how}) as is the case with many current parsing
-algorithms~\cite{Kats10b}. The syntax definition is used to make
-parsers that parse a textual representation of a program into its AST
-and pretty-printers for mapping ASTs back to text. However, due to its
-declarative nature, SDF3 is not limited to generating parsers and
+\emph{how}) as is the case with many current parser generators such as
+ANTLR and YACC~\cite{Kats10b}. The syntax definition is used to
+make parsers that parse a textual representation of a program into its
+AST and pretty-printers for mapping ASTs back to text. However, due to
+its declarative nature, SDF3 is not limited to generating parsers and
 pretty printers: it can also be used for error recovery
 rules~\cite{deJonge12}, syntax highlighting rules and folding
 rules for editors (see section \ref{sec:editor-serv}).
@@ -210,20 +210,17 @@ traversal order on the AST nodes.
 \subsection{Dynamic Semantics}
 \label{sec:dynamic-semantics}
 Dynamic semantics refers to how a program written in some language
-behaves~\cite{Winskel93}. There are multiple approaches to
-formally specify the dynamic semantics of a programming language (for
-an extensive treatment, see~\cite{Winskel93}). For this section
-only one sort of approach is relevant, namely \emph{operational semantics}.
+behaves~\cite{Winskel93}. There are many approaches to formally
+specify the dynamic semantics of a programming language (for an
+extensive treatment, see~\cite{Winskel93}). For this section only
+one sort of approach called \emph{operational semantics} is relevant.
 \subsubsection{DynSem: rule-based dynamic semantics}
 \label{ssec:dynsem}
-In Spoofax, the dynamic semantics of a language used to be specified
-with Stratego. However, the Spoofax team has developed a more
-high-level method to declare the dynamic semantics of a language,
-namely a DSL called \emph{DynSem}~\cite{VerguNV15}. As with all DSLs in
-Spoofax, DynSem offers a declarative approach to generate the
-\emph{implementation} out of the \emph{specification}. Indeed, from a DynSem
-specification of a language, an interpreter for that language can be
-generated.
+Aside from Stratego, the Spoofax team has developed an additional
+method to declare the dynamic semantics of a language, namely a DSL
+called \emph{DynSem}~\cite{VerguNV15}. DynSem allows for an operational
+semantics specification from which a Java-based AST interpreter can be
+automatically generated.
 
 In DynSem, the dynamic semantics are specified by means of rules. To
 show how rules can define the dynamic semantics of a language,
@@ -238,20 +235,21 @@ expression \(e_1\):
 
 In a similar way, dynamic semantics can be specified in DynSem, in a
 syntax very similar to the formal syntax used in the literature. Take
-here the example of defining method calling in paplj:
+here the example of defining the behaviour of some boolean operators
+in paplj:
 \lstset{language=dynsem,numbers=left}
 \begin{lstlisting}
 rules
-  // ...
-  Call(o, m, vs: List(V)) --> v'
-    where lookupMethod(o, m) --> Method(_, _, params, e);
-          This o, Env bindVars(params, vs) |- e --> v'.
+  And(BoolV(false), _) --> BoolV(false). 
+  And(BoolV(true), e)  --> e.
+   
+  Or(BoolV(true), _)  --> BoolV(true).
+  Or(BoolV(false), e) --> e.
 \end{lstlisting}
-The bottom line represents the rule of the method body, \(e\),
-evaluating to the return value \(v'\), by binding the argument values to
-the parameter in the environment and binding the \texttt{this} variable to
-the object on which the method is called. Exactly how \(e\) evaluates to
-\(v'\) is defined using other rules, which are left out in this example.
+The example applies the standard rules for boolean operators, and is
+sufficient to specify the behaviour of these operators. The rules are
+recursively applied to the expression \(e\) on the right-hand side of
+the rule until it eventually converges.
 \lstset{numbers=none}
 
 \subsection{Editor Services}

--- a/research/spoofax-org-export.tex
+++ b/research/spoofax-org-export.tex
@@ -221,9 +221,9 @@ The strategy \texttt{innermost} in this example is used to apply the strategy
 given as parameter (a composition of rewrite rules) in a specific
 traversal order on the AST nodes.
 
-The Spoofax API provides the \texttt{TranformService} for performing
-Transformation. Internally the \texttt{TransformService} access the Stratego
-runtime, which is accessed through the
+The Spoofax API provides the \texttt{TranformService} for performing program
+transformation. Internally the \texttt{TransformService} accesses the
+Stratego runtime, which is retrieved from the
 \texttt{StrategoRuntimeService}. Stratego also has support for \emph{native}
 strategies, which are specified in Java instead.
 \subsection{Dynamic Semantics}
@@ -283,17 +283,18 @@ This section concludes with a brief description of editor services,
 which provide the IDE support for languages defined in
 Spoofax. Examples of such services include an outline view, menus in
 which one can bind actions to menu buttons (see figure
-\ref{fig:menu-actions}), but also syntax highlighting, syntactic completion
-and code folding rules\footnote{More services are listed on
-the Spoofax website:
+\ref{fig:menu-actions}), but also syntax highlighting, syntactic code
+completion and code folding rules\footnote{More services are
+listed on the Spoofax website:
 \url{http://www.metaborg.org/spoofax/editor-services/}}.
 
 The Spoofax API provides the editor services with similar naming. For
 example, the outline can be retrieved from the \texttt{OutlineService}, the
 syntax highlighting can be accessed through the \texttt{StylerService} and
-syntactic completion is accessed with the \texttt{CompletionService}. The
-defined menus for a particular language can be retrieved with the
-\texttt{MenuService}, from which the menu actions can be retrieved and used.
+syntactic code completion is accessed with the
+\texttt{CompletionService}. The defined menus for a particular language can
+be retrieved with the \texttt{MenuService}, from which the menu actions can
+be retrieved and used.
 
 \begin{figure}[htb]
 \centering

--- a/research/spoofax-org-export.tex
+++ b/research/spoofax-org-export.tex
@@ -80,9 +80,15 @@ its declarative nature, SDF3 is not limited to generating parsers and
 pretty printers: it can also be used for error recovery
 rules~\cite{deJonge12}, syntax highlighting rules and folding
 rules for editors (see section \ref{sec:editor-serv}).
-
-All of the other parts of Spoofax use the AST that is produced by a
-parser generated from an SDF3 specification.
+\subsubsection{AST-based rules}
+\label{sec:orgheadline2}
+The meta-languages that will be discussed in the coming sections all
+have one property in common: all of them use \emph{rules} based on the AST
+in order to specify one of the parts of a language definition. The
+rules are said to be \emph{syntax-directed}: the specification for one AST
+node (whether it be a static semantics, rewriting or dynamic semantics
+specification) is done by the specification of the children of that
+AST node~\cite{Winskel93}.
 \subsection{Static Semantics}
 \label{sec:static-analysis}
 Static semantics refer to the meaning of what a well-formed program is
@@ -91,7 +97,7 @@ constraints than syntax definition, such as name binding, scoping
 rules and type checking. These cannot be specified by a syntax
 definition alone and are thus considered separately.
 \subsubsection{Declarative static semantics specification in Spoofax}
-\label{sec:orgheadline2}
+\label{sec:orgheadline3}
 In Spoofax, all the static semantics as well as the dynamic semantics
 used to be specified with the \emph{Stratego} transformation language
 (which is discussed in section \ref{sec:term-rewrite}). Nowadays, two
@@ -101,9 +107,10 @@ a variable can be set with NaBL, so that TS can be used to make
 assertions on the type of that variable.
 \subsubsection{NaBL: the Name Binding Language}
 \label{sec:nabl}
-With \emph{NaBL} (pronounced \emph{enable}), name binding and scoping rules can
-be specified declaratively~\cite{KonatKWV12}. Here is an example
-of the name binding and scoping rules for a class, from the \emph{paplj}
+With \emph{NaBL} (pronounced \emph{enable}), name binding and scoping can be
+specified declaratively using AST-based
+rules~\cite{KonatKWV12}. Here is an example of the name binding
+and scoping rules for a class, from the \emph{paplj}
 language\footnote{paplj is used as an exercise language for the
 ``Declare Your Language'' book, which is a work-in-progress at the time
 of writing. More information can be found here:
@@ -123,21 +130,17 @@ binding rules
     // Import namespaces from superclass
     imports Field, Method from Class c
 \end{lstlisting}
-The first line declares the \emph{namespaces} to consider. A namespace is a
-way to distinguish different kinds of
-names~\cite{KonatKWV12}. Then for each node in the AST resulting
-from the parsing, for example a \texttt{Class} node, the name binding and
-scoping rules can be defined. In the example, each \texttt{Class} node
-declares a new scope for its fields, methods and variables. It also
-implicitly defines the \texttt{this} variable. The \texttt{Extends} node can then
-import the fields and methods into its scope.
+The most important concept to take away from this example is the way
+the rules are specified on the AST: new scopes for names can be
+defined on the level of an AST node, and can be imported again by
+referring back to the scope definition.
 
 As can be seen from line 8, it can also associate type information
 with names to interplay with TS. The type annotations can also be used
 for instance when desugaring or rewriting with Stratego (see section
 \ref{sec:term-rewrite}).
 \subsubsection{TS: the Type Specification language}
-\label{sec:orgheadline3}
+\label{sec:orgheadline4}
 Type checking can be done by specifying typing rules with the \emph{TS}
 DSL. Again an example of the paplj language:
 \lstset{language=type-spec,numbers=left}
@@ -154,10 +157,12 @@ type rules
     where e1 : NumT() else error "number expected" on e1
       and e2 : NumT() else error "number expected" on e2
 \end{lstlisting}
-Rules can recursively set constraints on AST-nodes, such as the \texttt{Add}
-node in the above example.
+This example shows how in TS, the rules are syntax-directed: The
+typing rule of the \texttt{Add} node is specified by the types of its
+children \(e_1\) and \(e_2\), on which the typing rules will be applied
+recursively.
 
-Again, in line 5, interplay can be seen between TS an NaBL. Here the
+Again, in line 6, interplay can be seen between TS an NaBL. Here the
 type of a variable can be accessed, which is set in the NaBL
 specification (see the previous section \ref{sec:nabl}).
 \subsection{Term Rewriting and Program Transformation}
@@ -169,7 +174,7 @@ transformations are specified by \emph{term rewrite rules}: The left-hand
 side of a rule introduces a pattern (for example \(x + x\)), and the
 right-hand side specifies a replacement for it (e.g. \(2\cdot x\)).
 \subsubsection{Rewriting using Stratego}
-\label{sec:orgheadline4}
+\label{sec:orgheadline5}
 Spoofax offers a DSL called \emph{Stratego} for specifying program
 transformation with rewrite rules~\cite{Visser01}. Stratego can be
 seen as the most general part of Spoofax: before NaBL and TS, Stratego
@@ -188,7 +193,9 @@ rules
   	Let([b1, b2 | bs], e) -> Let([b1], Let([b2 | bs], e))
 \end{lstlisting}
 This desugars a \texttt{let} expression with multiple bindings into multiple
-nested \texttt{let} expressions each having just one binding.
+nested \texttt{let} expressions each having just one binding. Again it can be
+seen that these are syntax-directed rules, from the way the rules are
+specified using the AST.
 
 To construct the main algorithm of the program transformation,
 Stratego has the notion of \emph{strategies}. A strategy is used to specify
@@ -222,12 +229,12 @@ called \emph{DynSem}~\cite{VerguNV15}. DynSem allows for an operational
 semantics specification from which a Java-based AST interpreter can be
 automatically generated.
 
-In DynSem, the dynamic semantics are specified by means of rules. To
-show how rules can define the dynamic semantics of a language,
-consider the classic example of the \(\beta\)-reduction, which defines
-function application in the lambda calculus. The rule replaces all the
-occurences of the parameter \(x\) with the argument \(e_2\), within the
-expression \(e_1\):
+In DynSem, like other meta-languages in Spoofax, the dynamic semantics
+are specified by means of syntax-directed rules. To show how rules can
+define the dynamic semantics of a language, consider the classic
+example of the \(\beta\)-reduction, which defines function application in
+the lambda calculus. The rule replaces all the occurences of the
+parameter \(x\) with the argument \(e_2\), within the expression \(e_1\):
 
 \begin{equation}
 (\lambda x.e_1) e_2 \rightarrow e_1[x := e_2]
@@ -240,9 +247,9 @@ in paplj:
 \lstset{language=dynsem,numbers=left}
 \begin{lstlisting}
 rules
-  And(BoolV(false), _) --> BoolV(false). 
+  And(BoolV(false), _) --> BoolV(false).
   And(BoolV(true), e)  --> e.
-   
+
   Or(BoolV(true), _)  --> BoolV(true).
   Or(BoolV(false), e) --> e.
 \end{lstlisting}

--- a/research/spoofax-org-export.tex
+++ b/research/spoofax-org-export.tex
@@ -28,8 +28,8 @@ specification consists of the following conceptual steps:
 representations of a program are syntactically valid. A parser
 provides an implementation of this definition, by mapping a textual
 representation of a program to an abstract syntax tree (AST)
-representation. In Spoofax, the syntax is declared with a DSL
-called SDF.
+representation. In Spoofax, the syntax is declared with a domain
+specific language (DSL) called SDF.
 \item \hyperref[sec:static-analysis]{Static Semantics}: The AST then goes through static analysis (type
 checking, name binding and variable scoping), to test if the
 program is well-formed. Static semantics describe the rules for the
@@ -62,13 +62,12 @@ defines syntactically valid sentences made up of words.
 
 \subsubsection{SDF3: syntax definition in Spoofax}
 \label{sec:orgheadline1}
-To specify a syntax definition declaratively in Spoofax, a domain
-specific language (DSL) called \emph{SDF3}~\cite{Vollebregt12} is used.
-SDF3 is the third generation of the \emph{Syntax Definition Formalism}
-(SDF)~\cite{Heering89}. It uses only context-free grammer
-productions for the specification of both the lexical syntax and the
-context-free syntax, a feature that was introduced in
-SDF2~\cite{Visser97}.
+To specify a syntax definition declaratively in Spoofax, a DSL called
+\emph{SDF3}~\cite{Vollebregt12} is used.  SDF3 is the third generation
+of the \emph{Syntax Definition Formalism} (SDF)~\cite{Heering89}. It
+uses only context-free grammer productions for the specification of
+both the lexical syntax and the context-free syntax, a feature that
+was introduced in SDF2~\cite{Visser97}.
 
 The declarative nature of SDF3 allows for thinking in terms of the
 structure (the \emph{what}), instead of in terms of parser algorithms (the
@@ -224,8 +223,12 @@ traversal order on the AST nodes.
 The Spoofax API provides the \texttt{TranformService} for performing program
 transformation. Internally the \texttt{TransformService} accesses the
 Stratego runtime, which is retrieved from the
-\texttt{StrategoRuntimeService}. Stratego also has support for \emph{native}
-strategies, which are specified in Java instead.
+\texttt{StrategoRuntimeService}. The same holds for the \texttt{AnalysisService} of
+the previous section: it too uses the Stratego runtime.
+
+Stratego furthermore has support for \emph{native} strategies, which are
+specified in Java instead. Therefore the interface is bidirectional:
+Stratego can hook into Java, and Java can use the Stratego API.
 \subsection{Dynamic Semantics}
 \label{sec:dynamic-semantics}
 Dynamic semantics refers to how a program written in some language

--- a/research/spoofax-org-export.tex
+++ b/research/spoofax-org-export.tex
@@ -162,24 +162,22 @@ type of a variable can be accessed, which is set in the NaBL
 specification (see the previous section \ref{sec:nabl}).
 \subsection{Term Rewriting and Program Transformation}
 \label{sec:term-rewrite}
-Spoofax offers a high level declarative DSL called \emph{Stratego} for
-program transformation~\cite{Visser01}. Stratego operates on ASTs
-and is the most general part of Spoofax: it can be used for specifying
-the static semantics (name binding, type checking), desugaring rules
-and the dynamic semantics of a language. As the static semantics can
-now be done using NaBL and TS and the dynamic semantics with DynSem
-(section \ref{sec:dynamic-semantics}), Stratego is now used to specify
-desugaring rules for a language, as well as optimizations such as
-constant folding and other applications of AST transformations.
-
-Stratego is based on the notions of \emph{term rewrite rules} and so-called
-\emph{strategies}.
-\subsubsection{Term rewrite rules}
+Sometimes the AST needs some form of transformation before it is to be
+compiled or executed, for example to transform it to a canonical form,
+or to perform optimizations such as constant folding. Program
+transformations are specified by \emph{term rewrite rules}: The left-hand
+side of a rule introduces a pattern (for example \(x + x\)), and the
+right-hand side specifies a replacement for it (e.g. \(2\cdot x\)).
+\subsubsection{Rewriting using Stratego}
 \label{sec:orgheadline4}
-A rewrite rule is a transformation on a term, in which the left-hand
-side allows for pattern matching and variable binding and the right
-hand side instantiates new replacement terms. An example of a rewrite
-rule for paplj is given below.
+Spoofax offers a DSL called \emph{Stratego} for specifying program
+transformation with rewrite rules~\cite{Visser01}. Stratego can be
+seen as the most general part of Spoofax: before NaBL and TS, Stratego
+was used for specifying the static semantics. Moreover, being a
+program transformation language, it can also serve as a compiler and
+can thus be used to specify the dynamic semantics.
+
+An example of a rewrite rule for the paplj language is given below.
 \lstset{language=stratego,numbers=left}
 \begin{lstlisting}
 rules
@@ -191,12 +189,11 @@ rules
 \end{lstlisting}
 This desugars a \texttt{let} expression with multiple bindings into multiple
 nested \texttt{let} expressions each having just one binding.
-\subsubsection{Strategies}
-\label{sec:orgheadline5}
-Strategies are used to select and apply term rewrite rules, to
-construct the main algorithm of the program transformation. One can
-use multiple combinators to compose rewrite rules and other
-strategies. Another example from paplj is given below:
+
+To construct the main algorithm of the program transformation,
+Stratego has the notion of \emph{strategies}. A strategy is used to specify
+where and in what order the rewrite rules are applied to an
+AST. Another example from paplj is given below:
 \lstset{language=stratego,numbers=left}
 \begin{lstlisting}
 strategies
@@ -207,7 +204,7 @@ strategies
     innermost(desugar-do <+ desugar-get <+ desugar-set);
     resugar
 \end{lstlisting}
-For example, the strategy \texttt{innermost} is used to apply the strategy
+The strategy \texttt{innermost} in this example is used to apply the strategy
 given as parameter (a composition of rewrite rules) in a specific
 traversal order on the AST nodes.
 \subsection{Dynamic Semantics}
@@ -216,10 +213,7 @@ Dynamic semantics refers to how a program written in some language
 behaves~\cite{Winskel93}. There are multiple approaches to
 formally specify the dynamic semantics of a programming language (for
 an extensive treatment, see~\cite{Winskel93}). For this section
-only one sort of approach is relevant, namely \emph{rule-based operational}
-\emph{semantics} (see~\cite{Plotkin04} for a historical account of this
-approach).
-
+only one sort of approach is relevant, namely \emph{operational semantics}.
 \subsubsection{DynSem: rule-based dynamic semantics}
 \label{ssec:dynsem}
 In Spoofax, the dynamic semantics of a language used to be specified

--- a/research/spoofax-org-export.tex
+++ b/research/spoofax-org-export.tex
@@ -80,6 +80,9 @@ its declarative nature, SDF3 is not limited to generating parsers and
 pretty printers: it can also be used for error recovery
 rules~\cite{deJonge12}, syntax highlighting rules and folding
 rules for editors (see section \ref{sec:editor-serv}).
+
+The Spoofax API gives access to the generated parser through the
+\texttt{SyntaxService}.
 \subsubsection{AST-based rules}
 \label{sec:orgheadline2}
 The meta-languages that will be discussed in the coming sections all
@@ -105,6 +108,9 @@ high-level DSLs exist for specifying static semantics declaratively:
 NaBL and TS. The two DSLs can work together: for instance, the type of
 a variable can be set with NaBL, so that TS can be used to make
 assertions on the type of that variable.
+
+The static analysis step of a language is exposed through the Spoofax
+API by the \texttt{AnalysisService}.
 \subsubsection{NaBL: the Name Binding Language}
 \label{sec:nabl}
 With \emph{NaBL} (pronounced \emph{enable}), name binding and scoping can be
@@ -214,6 +220,12 @@ strategies
 The strategy \texttt{innermost} in this example is used to apply the strategy
 given as parameter (a composition of rewrite rules) in a specific
 traversal order on the AST nodes.
+
+The Spoofax API provides the \texttt{TranformService} for performing
+Transformation. Internally the \texttt{TransformService} access the Stratego
+runtime, which is accessed through the
+\texttt{StrategoRuntimeService}. Stratego also has support for \emph{native}
+strategies, which are specified in Java instead.
 \subsection{Dynamic Semantics}
 \label{sec:dynamic-semantics}
 Dynamic semantics refers to how a program written in some language
@@ -257,17 +269,31 @@ The example applies the standard rules for boolean operators, and is
 sufficient to specify the behaviour of these operators. The rules are
 recursively applied to the expression \(e\) on the right-hand side of
 the rule until it eventually converges.
-\lstset{numbers=none}
 
+DynSem generated interpreters can be accessed through the same APIs as
+those of Stratego, because the interpreter is a native Stratego
+strategy. Therefore, alternatively, the generated interpreter can also
+be accessed directly from Java provided that one has the AST of the
+program to interpret.
+
+\lstset{numbers=none}
 \subsection{Editor Services}
 \label{sec:editor-serv}
 This section concludes with a brief description of editor services,
 which provide the IDE support for languages defined in
 Spoofax. Examples of such services include an outline view, menus in
 which one can bind actions to menu buttons (see figure
-\ref{fig:menu-actions}), but also syntax highlighting and code folding
-rules\footnote{More services are listed on the Spoofax
-website: \url{http://www.metaborg.org/spoofax/editor-services/}}.
+\ref{fig:menu-actions}), but also syntax highlighting, syntactic completion
+and code folding rules\footnote{More services are listed on
+the Spoofax website:
+\url{http://www.metaborg.org/spoofax/editor-services/}}.
+
+The Spoofax API provides the editor services with similar naming. For
+example, the outline can be retrieved from the \texttt{OutlineService}, the
+syntax highlighting can be accessed through the \texttt{StylerService} and
+syntactic completion is accessed with the \texttt{CompletionService}. The
+defined menus for a particular language can be retrieved with the
+\texttt{MenuService}, from which the menu actions can be retrieved and used.
 
 \begin{figure}[htb]
 \centering
@@ -278,9 +304,9 @@ A menu action for the paplj language defined using Spoofax. The bottom window sh
 
 Editor services are defined using a DSL, shown in the bottom window of
 figure \ref{fig:menu-actions}. In the case of menus, their actions are
-specified using Stratego. Via Stratego these actions can even be
-specified in Java. As such, Spoofax allows for defining arbitrarily
-complex IDE actions.
+specified using Stratego. Since Stratego supports native strategies,
+these actions can also be specified in Java. As such, Spoofax allows
+for defining arbitrarily complex IDE actions.
 
 Many of these editor services such as syntax highlighting and code
 folding rules can be derived from the syntax


### PR DESCRIPTION
- [x] Describe and connect conceptual steps of language specification.
- [x] Mention Stratego in dynamic semantics.
- [x] Mention examples of parsing algorithms which are tainted by implementation details.
- [x] General concepts of NaBL and other DSLs (Discuss syntax directed rules).
- [x] Fix "most general part of Spoofax" claim about Stratego in Term Rewriting section.
- [x] Don't use "Rule-based operational semantics", use the term used in DynSem paper.
- [x] Reduce verbosity DynSem section.
- [ ] Improve examples. Try to use one concept for all examples.
- [x] Mention API services provided by Spoofax for all aspects.
