### PR TITLE
[RDY] Remove some sections in problem analysis

### DIFF
--- a/research/05-problem-ana.tex
+++ b/research/05-problem-ana.tex
@@ -99,20 +99,6 @@ needed, instead of being limited to running the whole build process at
 once.
 %- wat er gebeurt als je een stuk AST transplanteert waardoor een method ineens invalid return type heeft
 
-\subsubsection{Persistent REPL environment}
-\label{sec:pers-repl-envir}
-% - schrijven over environment als stratego term naar file kunnen saven
-
-\subsubsection{Showing the contents of the environment}
-\label{sec:show-cont-envir}
-% - uberhaupt listen van environment is mssn een interessante vraag
-
-\subsection{Extending the product with literate programming}
-\label{sec:extend-prod-with}
-
-\subsection{Plug-in development in Eclipse}
-\label{ssec:eclipse-plugins}
-
 %%% Local Variables:
 %%% mode: latex
 %%% TeX-master: "main"


### PR DESCRIPTION
I'm proposing the following changes:

Do we need to go in depth here? This can be dealt with in sprint 2 or 3.

> Persistent REPL environment
> Plug-in development in Eclipse

If we go for whole program execution first, this isn't needed either:

> Showing the contents of the environment

If we don't well first have to figure out how directly invoking the
HybridInterpreter works _and_ be able to parse partial programs before
we know how to tackle this problem.

Might be worthwhile to pursue IPython here, but can also be dealt with
in sprint 2 or 3.

> Extending the product with literate programming
